### PR TITLE
Fix last few typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,9 @@
 
 									<h5>21, Seite 401</h5>
 									<p>Tippfehler im Kasten, statt <code>@ EnableEurekaClient</code> sollte es <code>@EnableEurekaClient</code> lauten.
-								</div>
+
+									<h5>22.1, Seite 412</h5>
+									<p>Tippfehler im Kasten, statt "Spring Cloud Hystric" sollte es "Spring Cloud Hystrix" lauten.</p>								</div>
 							</section>
 						
 					</div>

--- a/index.html
+++ b/index.html
@@ -279,6 +279,9 @@
 										<li>Statt "[…] stehen allen anfragenden <b>Dateien</b> zur Verfügung." sollte es lauten "[…] stehen allen anfragenden <b>Anwendungen</b> zur Verfügung."</li>
 										<li>Tippfehler, es sollte "dieselben" statt "diesdelben" lauten.</li>
 									</ul>
+
+									<h5>21, Seite 401</h5>
+									<p>Tippfehler im Kasten, statt <code>@ EnableEurekaClient</code> sollte es <code>@EnableEurekaClient</code> lauten.
 								</div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -273,6 +273,12 @@
 
 									<h5>18.4.1, Seite 385</h5>
 									<p>Tippfehler, es muss "lesend und schreibend" statt "schreiben" lauten.</p>
+
+									<h5>20.1, Seite 399</h5>
+									<ul>
+										<li>Statt "[…] stehen allen anfragenden <b>Dateien</b> zur Verfügung." sollte es lauten "[…] stehen allen anfragenden <b>Anwendungen</b> zur Verfügung."</li>
+										<li>Tippfehler, es sollte "dieselben" statt "diesdelben" lauten.</li>
+									</ul>
 								</div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
 									<h5>A.2, Seite 422</h5>
 									<p>Die <code>@Bean</code>-Annotation im Fließtext sollte eigentlich in Monospace formatiert sein.</p>
 
-									<h5>C.1, Seite 434</h5>
+									<h5>C.2, Seite 434</h5>
 									<p>Tippfehler, statt "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als zum neuen WebFlux-Modul gehören können, […]" sollte es "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als auch zum neuen WebFlux-Modul gehören können, […]" lauten.</p>
                                 </div>
 							</section>

--- a/index.html
+++ b/index.html
@@ -274,6 +274,16 @@
 									<h5>18.4.1, Seite 385</h5>
 									<p>Tippfehler, es muss "lesend und schreibend" statt "schreiben" lauten.</p>
 
+<!--									<h5>19.1, Seite 391</h5>-->
+<!--									<p>-->
+<!--										Das Wort Trade-Off wurde mMn. (!) falsch verwendet:-->
+<!--										"Trotz aller Trade-Offs haben Microservice-Systeme viele Vorteile."-->
+<!--										Trade-Offs implizieren ja schon, dass es mit den Vorteilen auch zwingend Nachteile gibt (und ggf. umgekehrt).-->
+<!--										Stattdessen könnte es ungefähr wie folgt lauten:-->
+<!--										"Trotz der genannten Nachteile […]".-->
+<!--										Dass es eine Zielkonflikt/Trade-Off gibt bzw. einen Kompromiss, der eingegangen werden muss, würde ich in einem separate Satz erläutern.-->
+<!--									</p>-->
+
 									<h5>20.1, Seite 399</h5>
 									<ul>
 										<li>Statt "[…] stehen allen anfragenden <b>Dateien</b> zur Verfügung." sollte es lauten "[…] stehen allen anfragenden <b>Anwendungen</b> zur Verfügung."</li>

--- a/index.html
+++ b/index.html
@@ -284,10 +284,11 @@
 									<p>Tippfehler im Kasten, statt <code>@ EnableEurekaClient</code> sollte es <code>@EnableEurekaClient</code> lauten.
 
 									<h5>22.1, Seite 412</h5>
-									<p>Tippfehler im Kasten, statt "Spring Cloud Hystric" sollte es "Spring Cloud Hystrix" lauten.</p>								</div>
+									<p>Tippfehler im Kasten, statt "Spring Cloud Hystric" sollte es "Spring Cloud Hystrix" lauten.</p>
 
 									<h5>23, Seite 417</h5>
-									<p>Tippfehler, statt "Der To-do-Service regiert […]" sollte es "Der To-do-Service reagiert […]" lauten.</p>								</div>
+									<p>Tippfehler, statt "Der To-do-Service regiert […]" sollte es "Der To-do-Service reagiert […]" lauten.</p>
+                                </div>
 							</section>
 						
 					</div>

--- a/index.html
+++ b/index.html
@@ -285,6 +285,9 @@
 
 									<h5>22.1, Seite 412</h5>
 									<p>Tippfehler im Kasten, statt "Spring Cloud Hystric" sollte es "Spring Cloud Hystrix" lauten.</p>								</div>
+
+									<h5>23, Seite 417</h5>
+									<p>Tippfehler, statt "Der To-do-Service regiert […]" sollte es "Der To-do-Service reagiert […]" lauten.</p>								</div>
 							</section>
 						
 					</div>

--- a/index.html
+++ b/index.html
@@ -294,6 +294,9 @@
 
 									<h5>C.2, Seite 434</h5>
 									<p>Tippfehler, statt "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als zum neuen WebFlux-Modul gehören können, […]" sollte es "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als auch zum neuen WebFlux-Modul gehören können, […]" lauten.</p>
+
+									<h5>C.2, Seite 435</h5>
+									<p>Tippfehler, einmal wurde provideragnostisch und kurz darauf provider-agnostisch geschrieben.</p>
                                 </div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
 									<p>Die Basis-URL der Endpunkte wird über <code>management.endpoints.web.base-path</code> konfiguriert, die Pfade einzelner Endpunkte über <code>management.endpoints.web.path-mapping.health=healthcheck.&lt;id&gt;</code>, der Kontext-Pfad der Actuator-Endpunkte über <code>management.server.servlet.context-path</code>.</p>
 
 									<h5>17.6, Seite 360</h5>
-									<p>Tippfehler, zuviele Whitespaces: "[…] unter dem Schlüssel <code>org.springframework.boot.actuate.autoconfigure.ManagementContextConfigurstion</code> aufgelistet werden;[…]"</p>
+									<p>Tippfehler, zu viele Whitespaces: "[…] unter dem Schlüssel <code>org.springframework.boot.actuate.autoconfigure.ManagementContextConfigurstion</code> aufgelistet werden;[…]"</p>
 
 									<h5>18.4.1, Seite 385</h5>
 									<p>Tippfehler, es muss "lesend und schreibend" statt "schreiben" lauten.</p>

--- a/index.html
+++ b/index.html
@@ -227,15 +227,11 @@
 										<li>Tippfehler, richtig lautet es "In diesen Fällen […]"</li>
 									</ul>
 
-									<h5>17.2.2, Seite 347</h5>
-									<p>Die Basis-URL der Endpunkte wird über <code>management.endpoints.web.base-path</code> konfiguriert, die Pfade einzelner Endpunkte über <code>management.endpoints.web.path-mapping.health=healthcheck.&lt;id&gt;</code>, der Kontext-Pfad der Actuator-Endpunkte über <code>management.server.servlet.context-path</code>.</p>
-									
 									<h5>14.2, Seite 273</h5>
 									<p>"Das WebFlux Modul ist sowohl in einem klassischen Servlet-Container als […]"</p>
 									
 									<h5>14.2.3, Seite 283</h5>
 									<p>"[…], welche Request-Methode auf welchem Pfad genutzt wurde […]"</p>
-									
 									
 									<h5>15.1, Seite 297</h5>
 									<p>Tippfehler, "Sprint-Test" statt "Spring-Test".</p>
@@ -265,7 +261,10 @@
 											}
 										</code>
 									</p>
-										
+
+									<h5>17.2.2, Seite 347</h5>
+									<p>Die Basis-URL der Endpunkte wird über <code>management.endpoints.web.base-path</code> konfiguriert, die Pfade einzelner Endpunkte über <code>management.endpoints.web.path-mapping.health=healthcheck.&lt;id&gt;</code>, der Kontext-Pfad der Actuator-Endpunkte über <code>management.server.servlet.context-path</code>.</p>
+
 									<h5>17.6, Seite 360</h5>
 									<p>Tippfehler, zuviele Whitespaces: "[…] unter dem Schlüssel <code>org.springframework.boot.actuate.autoconfigure.ManagementContextConfigurstion</code> aufgelistet werden;[…]"</p>
 

--- a/index.html
+++ b/index.html
@@ -111,6 +111,15 @@
 										Ganz besonderen Dank geht an Herrn Matthias Streidel, der mit enormer Sorgfalt mein Buch gelesen hat und sich nicht nur die Mühe gemacht hat, 
 										mir Seitenzahlen, Kapitel und Screenshots mit Korrekturen zu schicken, sondern auch zu dieser Seite beigetragen hat.
 									</p>
+
+<!--									<h5>Allgemein im ganzen Buch, ggf. im fertigen Projekt dann suchen und ersetzen.</h5>-->
+<!--									<ul>-->
+<!--										<li>https</li>-->
+<!--										<li>Uneinheitliche Schreibweise bei JSRs. Mit einem Minus getrennt muss es übrigens nicht korrekt sein. Auf Wikipedia wird z.B. "JSR 123" statt "JSR-123" geschrieben, aber ich persönlich empfinde es mit einem Trennstrich korrekt.</li>-->
+<!--										<li>Uneinheitliche Schreibweise bei "mithilfe" und "mit Hilfe". Ich persönlich finde erstere korrekt, meine kurze Recherche hat das auch bestätigt. Am Ende sollte es einheitlich sein, egal welche Variante verwendet wird.</li>-->
+<!--										<li>Doppelte Whitespaces</li>-->
+<!--										<li></li>-->
+<!--									</ul>-->
 									
 									<h5>3.1.2, letzter Abschnitt</h5>
 									<p>

--- a/index.html
+++ b/index.html
@@ -288,6 +288,9 @@
 
 									<h5>23, Seite 417</h5>
 									<p>Tippfehler, statt "Der To-do-Service regiert […]" sollte es "Der To-do-Service reagiert […]" lauten.</p>
+
+									<h5>A.2, Seite 422</h5>
+									<p>Die <code>@Bean</code>-Annotation im Fließtext sollte eigentlich in Monospace formatiert sein.</p>
                                 </div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -291,6 +291,9 @@
 
 									<h5>A.2, Seite 422</h5>
 									<p>Die <code>@Bean</code>-Annotation im Fließtext sollte eigentlich in Monospace formatiert sein.</p>
+
+									<h5>C.1, Seite 434</h5>
+									<p>Tippfehler, statt "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als zum neuen WebFlux-Modul gehören können, […]" sollte es "Insbesondere Strukturen, die inhaltlich sowohl zur bestehenden Servlet-API als auch zum neuen WebFlux-Modul gehören können, […]" lauten.</p>
                                 </div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -297,6 +297,12 @@
 
 									<h5>C.2, Seite 435</h5>
 									<p>Tippfehler, einmal wurde provideragnostisch und kurz darauf provider-agnostisch geschrieben.</p>
+
+									<h5>C.2, Seite 437</h5>
+									<ul>
+										<li>Tippfehler, statt "Hikaru" sollt es "Hikari" lauten.</li>
+										<li>Tippfehler, statt "Spring-Securitys-Default" sollte es "Spring-Security-Default" lauten.</li>
+									</ul>
                                 </div>
 							</section>
 						

--- a/index.html
+++ b/index.html
@@ -268,6 +268,9 @@
 									<h5>17.6, Seite 360</h5>
 									<p>Tippfehler, zu viele Whitespaces: "[…] unter dem Schlüssel <code>org.springframework.boot.actuate.autoconfigure.ManagementContextConfigurstion</code> aufgelistet werden;[…]"</p>
 
+									<h5>18.3.1, Seite 376</h5>
+									<p>Tippfehler im Kasten, dort wird dreimal das Projekt <i>helloword_war</i> genannt, u.a. im Verweis auf Github. Gemeint ist aber stets helloworld_war</p>
+
 									<h5>18.4.1, Seite 385</h5>
 									<p>Tippfehler, es muss "lesend und schreibend" statt "schreiben" lauten.</p>
 								</div>


### PR DESCRIPTION
Bitte die Korrekturen wieder prüfen, da ich nicht garantieren kann dass ich nicht einfach einen False-Positive mit eingebaut habe. Es sind auch Anmerkungen als HTML Kommentar eingecheckt, damit diese nicht verloren gehen.
Glossar und Abkürzungeverzeichnis habe wurden nicht geprüft. 